### PR TITLE
fix(chat): audio icon/title and keep only filename

### DIFF
--- a/src/components/chat/messages/index.js
+++ b/src/components/chat/messages/index.js
@@ -83,6 +83,8 @@ const Messages = ({
                     url={item.url}
                     timestamp={timestamp}
                     type={item.type}
+                    isAudio={item.isAudio}
+                    isLocal={item.isLocal}
                   />
                 </span>
               );

--- a/src/components/chat/messages/system/video/index.js
+++ b/src/components/chat/messages/system/video/index.js
@@ -9,9 +9,13 @@ import SystemMessage from 'components/chat/messages/system/message';
 import { ID } from 'utils/constants';
 
 const intlMessages = defineMessages({
-  name: {
+  videoName: {
     id: 'player.chat.message.video.name',
     description: 'Label for the video message name',
+  },
+  audioName: {
+    id: 'player.chat.message.audio.name',
+    description: 'Label for the audio message name',
   },
 });
 
@@ -19,31 +23,43 @@ const propTypes = {
   active: PropTypes.bool,
   url: PropTypes.url,
   timestamp: PropTypes.number,
+  isAudio: PropTypes.bool,
+  isLocal: PropTypes.bool,
 };
 
 const defaultProps = {
   active: false,
   url: '',
   timestamp: 0,
+  isAudio: false,
+  isLocal: false,
 };
+
+// leave just the fileName for local files
+const formatUrl = (url) => {
+  const urlParams = new URLSearchParams(url);
+  return Array.from(urlParams.values())[0];
+}
 
 const Video = ({
   active,
   url,
   timestamp,
+  isAudio,
+  isLocal,
 }) => {
   const intl = useIntl();
 
   return (
     <SystemMessage
       active={active}
-      icon={ID.VIDEOS}
-      name={intl.formatMessage(intlMessages.name)}
+      icon={isAudio ? 'audios' : ID.VIDEOS}
+      name={isAudio ? intl.formatMessage(intlMessages.audioName) : intl.formatMessage(intlMessages.videoName)}
       timestamp={timestamp}
     >
       <Url
         active={active}
-        url={url}
+        url={isLocal ? formatUrl(url) : url}
       />
     </SystemMessage>
   );

--- a/src/components/utils/icon/index.scss
+++ b/src/components/utils/icon/index.scss
@@ -85,6 +85,11 @@
   content: "\e801";
 }
 
+.icon-audios:before {
+  content: "\e91a";
+}
+
+
 .icon-webcams:before {
   content: "\e930";
 }

--- a/src/locales/messages/en.json
+++ b/src/locales/messages/en.json
@@ -33,6 +33,7 @@
   "player.chat.message.question.name": "Question",
   "player.chat.message.question.answer": "Answer",
   "player.chat.message.video.name": "External video",
+  "player.chat.message.audio.name": "Audio player",
   "player.chat.wrapper.aria": "Chat area",
   "player.notes.wrapper.aria": "Notes area",
   "player.presentation.wrapper.aria": "Presentation area",

--- a/src/locales/messages/pt_BR.json
+++ b/src/locales/messages/pt_BR.json
@@ -20,6 +20,8 @@
   "player.chat.message.poll.option.false": "Falso",
   "player.chat.message.question.name": "Pergunta",
   "player.chat.message.question.answer": "Resposta",
+  "player.chat.message.video.name": "Vídeo externo",
+  "player.chat.message.audio.name": "Player de áudio",
   "player.chat.wrapper.aria": "Área do bate-papo",
   "player.notes.wrapper.aria": "Área das anotações",
   "player.presentation.wrapper.aria": "Área da apresentação",

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -112,6 +112,8 @@ const buildVideos = result => {
     return {
       timestamp: r.timestamp,
       url: r.external_video_url,
+      isAudio: r?.is_audio === 'true',
+      isLocal: r?.is_local === 'true',
     };
   });
 


### PR DESCRIPTION
Better chat message visual for audio/media uploads.

Before: 
![image](https://github.com/mconf/bbb-playback/assets/2726293/82b2d107-10f5-4b76-b936-d590731fab28)

After:
![image](https://github.com/mconf/bbb-playback/assets/2726293/3aa9d78c-2f44-4968-94f6-7d969373dae1)


Needs https://github.com/mconf/mconf-live/pull/1901
Closes https://github.com/mconf/mconf-tracker/issues/1627